### PR TITLE
Fixed a not display correctly in ranking page when player score is out t of Strategy::RANK.

### DIFF
--- a/app/models/league.rb
+++ b/app/models/league.rb
@@ -45,9 +45,10 @@ class League < ActiveRecord::Base
   end
 
   def rank(strategy)
-    Strategy::RANK.each do |range, rank|
+    result = Strategy::RANK.each do |range, rank|
       return rank if range.include?(achievement(strategy))
     end
+    return 'SSSS' if result == Strategy::RANK
   end
 
   def achievement(strategy)

--- a/spec/factories/strategies.rb
+++ b/spec/factories/strategies.rb
@@ -60,6 +60,13 @@ FactoryGirl.define do
       statement 485
       func_num 17
     end
+
+    trait :type6 do
+      score 400
+      abc_size 1.0
+      statement 1
+      func_num 1
+    end
   end
 end
 

--- a/spec/models/league_spec.rb
+++ b/spec/models/league_spec.rb
@@ -27,5 +27,19 @@ RSpec.describe League, type: :model do
   it 'ディレクトリが生成される' do
     expect(File.exist?(league.data_dir)).to eq true
   end
+
+  describe 'Leagues#rank' do
+
+    it '正常のスコアで期待したランクが表示される' do
+      rank_list = [nil, 'C', 'X', 'X', 'C', 'X', 'SSSS']
+      1.upto(6) do |i|
+        sym = ('type' + i.to_s).to_sym
+        strategy = create :strategy, sym, submit_id: i
+        expect(rank_list[i]).to eq(league.rank(strategy))
+      end
+    end
+  end
+
+
 end
 


### PR DESCRIPTION
I found bug in wint.
Maybe, expected to view 'SSSS', but got to hash value in ranking page.
You should consider a range of rank in ranking page.

![2016-11-30 2 59 53](https://cloud.githubusercontent.com/assets/9594376/20722224/1990b6ca-b6a9-11e6-995f-b3e4e566b60b.png)
